### PR TITLE
Fixed upload-file tmp file space leak

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -217,23 +217,24 @@ class ResourceUpload(object):
                 if e.errno != 17:
                     raise
             tmp_filepath = filepath + '~'
-            output_file = open(tmp_filepath, 'wb+')
-            self.upload_file.seek(0)
-            current_size = 0
-            while True:
-                current_size = current_size + 1
-                #MB chunks
-                data = self.upload_file.read(2 ** 20)
-                if not data:
-                    break
-                output_file.write(data)
-                if current_size > max_size:
-                    os.remove(tmp_filepath)
-                    raise logic.ValidationError(
-                        {'upload': ['File upload too large']}
-                    )
-            output_file.close()
-            os.rename(tmp_filepath, filepath)
+            with open(tmp_filepath, 'wb+') as output_file:
+                with self.upload_file:
+                    self.upload_file.seek(0)
+                    current_size = 0
+                    while True:
+                        current_size = current_size + 1
+                        # MB chunks
+                        data = self.upload_file.read(2 ** 20)
+
+                        if not data:
+                            break
+                        output_file.write(data)
+                        if current_size > max_size:
+                            os.remove(tmp_filepath)
+                            raise logic.ValidationError(
+                                {'upload': ['File upload too large']}
+                            )
+                os.rename(tmp_filepath, filepath)
             return
 
         # The resource form only sets self.clear (via the input clear_upload)


### PR DESCRIPTION
Cherry picked from https://github.com/ckan/ckan/issues/3752 (with modifications)

Moved common_middleware.py and pylons_app.py changes to middleware.py

Updated "if upload:" to "if upload is not None:" because otherwise it
evaluated to false and skipped the "upload.fp.close()". This change was
added to the ckan PR by smotornyuk.

https://trello.com/c/oP4frPB6/200-very-large-files-cannot-be-added-to-open-government-portal