### PR TITLE
Fixed upload-file tmp file space leak

### DIFF
--- a/ckan/config/middleware/pylons_app.py
+++ b/ckan/config/middleware/pylons_app.py
@@ -55,6 +55,8 @@ def make_pylons_stack(conf, full_stack=True, static_files=True,
     for plugin in PluginImplementations(IMiddleware):
         app = plugin.make_middleware(app, config)
 
+    app = common_middleware.CloseWSGIInputMiddleware(app, config)
+
     # Routing/Session/Cache Middleware
     app = RoutesMiddleware(app, config['routes.map'])
     # we want to be able to retrieve the routes middleware to be able to update

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -17,6 +17,21 @@ _max_resource_size = None
 _max_image_size = None
 
 
+def _copy_file(input_file, output_file, max_size):
+    input_file.seek(0)
+    current_size = 0
+    while True:
+        current_size = current_size + 1
+        # MB chunks
+        data = input_file.read(2**20)
+
+        if not data:
+            break
+        output_file.write(data)
+        if current_size > max_size:
+            raise logic.ValidationError({'upload': ['File upload too large']})
+
+
 def get_uploader(upload_to, old_filename=None):
     '''Query IUploader plugins and return an uploader instance for general
     files.'''
@@ -151,22 +166,14 @@ class Upload(object):
         max_size is size in MB maximum of the file'''
 
         if self.filename:
-            output_file = open(self.tmp_filepath, 'wb')
-            self.upload_file.seek(0)
-            current_size = 0
-            while True:
-                current_size = current_size + 1
-                # MB chunks
-                data = self.upload_file.read(2 ** 20)
-                if not data:
-                    break
-                output_file.write(data)
-                if current_size > max_size:
+            with open(self.tmp_filepath, 'wb+') as output_file:
+                try:
+                    _copy_file(self.upload_file, output_file, max_size)
+                except logic.ValidationError:
                     os.remove(self.tmp_filepath)
-                    raise logic.ValidationError(
-                        {self.file_field: ['File upload too large']}
-                    )
-            output_file.close()
+                    raise
+                finally:
+                    self.upload_file.close()
             os.rename(self.tmp_filepath, self.filepath)
             self.clear = True
 
@@ -247,22 +254,14 @@ class ResourceUpload(object):
                 if e.errno != 17:
                     raise
             tmp_filepath = filepath + '~'
-            output_file = open(tmp_filepath, 'wb+')
-            self.upload_file.seek(0)
-            current_size = 0
-            while True:
-                current_size = current_size + 1
-                # MB chunks
-                data = self.upload_file.read(2 ** 20)
-                if not data:
-                    break
-                output_file.write(data)
-                if current_size > max_size:
+            with open(tmp_filepath, 'wb+') as output_file:
+                try:
+                    _copy_file(self.upload_file, output_file, max_size)
+                except logic.ValidationError:
                     os.remove(tmp_filepath)
-                    raise logic.ValidationError(
-                        {'upload': ['File upload too large']}
-                    )
-            output_file.close()
+                    raise
+                finally:
+                    self.upload_file.close()
             os.rename(tmp_filepath, filepath)
             return
 


### PR DESCRIPTION
Fix version 3 ported to 2.6.0 branch

Cherry picked from:
ckan@c96c216

It is basically the exact same fix only I applied it manually after
getting merge conflicts.

Note that CloseWSGIInputMiddleware must go right after
PluginImplementations plugin.make_middleware loop. The location in the
pylons app pipeline is critical. In the cherry-picked original, it is
right before RootPathMiddleware. But not in this version for 2.6.0. This
RootPathMiddleware line is in a different place in 2.6.0.

Version 3 brings in some improvements changes from ckan. Form vars
named other than "upload" have the leak fixed also. Too-large uploads
do not have the leak when they error. os.rename is moved to a safer
location. Some refactoring was done. Version 2 still essentially fixes
the problem.

Tested on dev-local.

To see the leak:
watch -n .2 'df -h; echo; sudo lsof -c python -c httpd -c nginx | grep
/tmp'

(lsof views deleted "Stale file handle" files which ckan holds on to but
are not visible from "ls" or "find" - this shows the leak)

Original card for 2.3.5
https://trello.com/c/oP4frPB6/200-very-large-files-cannot-be-added-to-open-government-portal

Fix version 2 card: Fix: upload dies - small file uploads and create-links fail
https://trello.com/c/mCTGrKdu/517-fix-large-file-upload-errors?menu=filter&filter=@curtisyallop1

Fix version 2 on 2.3.5 code:
eb4ff13

Fix version 3 ported to ckan 2.6.0 card:
https://trello.com/c/1tDpPqip/449-make-ckan-260-version-of-upload-file-tmp-file-space-leak-fix