### PR TITLE
Fix broken upload-file fix

### DIFF
--- a/ckan/config/middleware.py
+++ b/ckan/config/middleware.py
@@ -248,7 +248,7 @@ class CloseWSGIInputMiddleware(object):
         wsgi_input = environ['wsgi.input']
         if isinstance(wsgi_input, FakeCGIBody):
             upload = wsgi_input.vars.get('upload')
-            if upload is not None:
+            if hasattr(upload, 'fp'):
                 upload.fp.close()
         return self.app(environ, start_response)
 

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -211,14 +211,14 @@ class ResourceUpload(object):
         # in the same location
         if self.filename:
             try:
-                os.makedirs(directory)
-            except OSError, e:
-                ## errno 17 is file already exists
-                if e.errno != 17:
-                    raise
-            tmp_filepath = filepath + '~'
-            with open(tmp_filepath, 'wb+') as output_file:
-                with self.upload_file:
+                try:
+                    os.makedirs(directory)
+                except OSError, e:
+                    ## errno 17 is file already exists
+                    if e.errno != 17:
+                        raise
+                tmp_filepath = filepath + '~'
+                with open(tmp_filepath, 'wb+') as output_file:
                     self.upload_file.seek(0)
                     current_size = 0
                     while True:
@@ -234,7 +234,9 @@ class ResourceUpload(object):
                             raise logic.ValidationError(
                                 {'upload': ['File upload too large']}
                             )
-                os.rename(tmp_filepath, filepath)
+                    os.rename(tmp_filepath, filepath)
+            finally:
+                self.upload_file.close()
             return
 
         # The resource form only sets self.clear (via the input clear_upload)


### PR DESCRIPTION
Fix 1

For small files, self.upload_file in uploader.py is a StringO
(cStringIO.OutputType) not a file so "with:" fails. Replaced "with:"
with a self.upload_file.close(). In this 2.3.5 version, I accidentally
grabbed the old version of the fix from the ckan people before they
made this exact fix.

Put this upload_file.close() in a try-finally block so that any
exceptions (eg the file size exceeds the max), will close the file
and not cause a tmp space leak.

Fix 2

For resources which are a link, "upload" in middleware.py is type
string, not type cgi.FieldStorage. It is actually an empty string.
It can also be "None" for regular non-upload http requests. So now
before closing upload.fp, we make sure that "upload" implements "fp".
Note that "if upload:" is false for type FieldStorage.

https://trello.com/c/mCTGrKdu/517-fix-large-file-upload-errors
