### PR TITLE
Converted extras to a list before create/update an organization.

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -851,6 +851,8 @@ def organization_create(context, data_dict):
     '''
     # wrapper for creating organizations
     data_dict.setdefault('type', 'organization')
+    if 'extras' in data_dict and (type(data_dict['extras']) is str or type(data_dict['extras']) is unicode ):
+        data_dict['extras'] = json.loads(data_dict['extras'])
     _check_access('organization_create', context, data_dict)
     return _group_or_org_create(context, data_dict, is_org=True)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -613,6 +613,8 @@ def organization_update(context, data_dict):
     # Callers that set context['allow_partial_update'] = True can choose to not
     # specify particular keys and they will be left at their existing
     # values. This includes: users, groups, tags, extras
+    if 'extras' in data_dict and (type(data_dict['extras']) is str or type(data_dict['extras']) is unicode ):
+        data_dict['extras'] = json.loads(data_dict['extras'])
     return _group_or_org_update(context, data_dict, is_org=True)
 
 def user_update(context, data_dict):


### PR DESCRIPTION
Fixes #

### Proposed fixes:
Converted 'extras' to a list before create/update an organization in action


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
